### PR TITLE
fix(CI): add permission on what GITHUB_TOKEN can do

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   cd:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to define explicit permissions for continuous delivery processes. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->