### PR TITLE
fix(dashboard): expose NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY as fallback when it fails to load env

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,14 +38,8 @@ jobs:
         if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
         run: |
           make latest
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
 
       - name: Build release image
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           make release
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}

--- a/.github/workflows/ts-ci.yaml
+++ b/.github/workflows/ts-ci.yaml
@@ -48,6 +48,3 @@ jobs:
 
       - name: Run Build
         run: pnpm run build
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}

--- a/apps/dashboard/components/providers.tsx
+++ b/apps/dashboard/components/providers.tsx
@@ -6,7 +6,12 @@ import * as React from "react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ClerkProvider>
+    <ClerkProvider
+      publishableKey={
+        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ||
+        "pk_test_YXJyaXZpbmctbGVtbWluZy0yOS5jbGVyay5hY2NvdW50cy5kZXYk"
+      }
+    >
       <NextThemesProvider
         attribute="class"
         defaultTheme="system"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations to remove Clerk-related environment variables from build and CI steps.

- **New Features**
	- The Providers component now ensures the Clerk provider receives a publishable key, using an environment variable if available or a test key as fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->